### PR TITLE
Supports option "rejectUnauthorized" to enable/disable validating certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ __Arguments__
         - host: eg: "192.168.0.1"
         - port: eg: 8888
         - protocol: (default: __'http'__ ) can be 'http' or 'https'
+    - rejectUnauthorized: (default: __true__), validate certificate for request with HTTPS
  - callback(err, res): A callback function which is called when the request is complete. __res__ contains the headers ( __res.headers__ ), the http status code ( __res.statusCode__ ) and the body ( __res.body__ )
 
 __Example without extra options__

--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -120,6 +120,7 @@ function doRequest(o, callback){
 	var host;
 	var path;
 	var isHttps = false;
+	var rejectUnauthorized = true;
 
 	if(o.proxy){
 		port = o.proxy.port;
@@ -214,12 +215,20 @@ function doRequest(o, callback){
 		contentType = null;
 	}
 
+	if(
+		('rejectUnauthorized' in o) &&
+		(o.rejectUnauthorized === false)
+	){
+		rejectUnauthorized = false;
+	}
+
 	var requestoptions = {
 		host: host,
 		port: port,
 		path: path,
 		method: o.method,
-		headers: {}
+		headers: {},
+		rejectUnauthorized: rejectUnauthorized
 	};
 
 	if(!o.redirectCount){


### PR DESCRIPTION
Nodejs 0.9.2+ validates server certificates by default.
Set option `rejectUnauthorized` to enable/disable validating server certification for HTTPS request.
