### PR TITLE
Proper way to set and handle timeout

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -111,7 +111,6 @@ function doRequest(o, callback){
 		o.maxRedirects = 10;
 	}
 
-	var hasTimedout = false;
 	var chunks = [];
 	var body; // Buffer
 	var contentType;
@@ -338,20 +337,19 @@ function doRequest(o, callback){
 		request = http.request(requestoptions, requestResponse);
 
 	if(o.timeout){
-		request.setTimeout(o.timeout, function (k, d){
-			hasTimedout = true;
-			request.abort();
+		request.on('socket', function(socket){
+			socket.on('timeout', function() {
+				var err = new Error('request timed out');
+				err.code = 'TIMEOUT';
+				callback(err);
+				request.abort();
+			});
+			socket.setTimeout(o.timeout);
 		});
 	}
 
 	request.on('error', function (err) {
-		if(hasTimedout){
-			var err = new Error("request timed out");
-			err.code = 'TIMEOUT';
-			callback(err);
-		} else {
-			callback(err);
-		}
+		callback(err);
 	});
 
 	if(body)

--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -100,10 +100,19 @@ exports.uploadFiles = function(options, callback){
 }
 
 
-function doRequest(o, callback){
-	if(!callback){
-		callback = function (err) {
+function doRequest(o, doCallback){
+	if(!doCallback){
+		doCallback = function (err) {
 			// dummy function
+		}
+	}
+
+	// prevent multiple callbacks
+	var isDone = false;
+	function callback(err, res) {
+		if(!isDone) {
+			isDone = true;
+			doCallback(err, res);
 		}
 	}
 


### PR DESCRIPTION
Most of the time `request.setTimeout` does not work because there is no `socket` yet to apply it to. Better is to wait for the socket to be ready and then do `socket.setTimeout`. The nice part is that `socket` can emit a `timeout` event, which you can use the destroy the `request`.

Even though the request is destroyed other events may still fire causing the `callback` function to be called multiple times. That can also happen with the `response close` event that sometimes fires after `response end` has already emitted. Pretty annoying async stuff. The second commit prevents that.