### PR TITLE
Added HTTPS options key, cert, secureProtocol

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -247,6 +247,18 @@ function doRequest(o, callback){
 		requestoptions.rejectUnauthorized = o.rejectUnauthorized;
 	}
 
+	if(isHttps && o.key){
+		requestoptions.key = o.key;
+	}
+
+	if(isHttps && o.cert){
+		requestoptions.cert = o.cert;
+	}
+
+	if(isHttps && o.secureProtocol) {
+		requestoptions.secureProtocol = o.secureProtocol;
+	}
+
 	// add custom headers:
 	if(o.headers){
 		for(var headerkey in o.headers){


### PR DESCRIPTION
Send client certificate to remote host and set the required protocol, i.e. `TLSv1_method` to avoid SSLv3.