### PR TITLE
Timeout must always be an integer

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -369,7 +369,7 @@ function doRequest(o, callback){
 				finalCallback(err);
 				request.abort();
 			});
-			socket.setTimeout(o.timeout);
+			socket.setTimeout(parseInt (o.timeout, 10));
 		});
 	}
 


### PR DESCRIPTION
Just ran into this issue where the timeout value was passed as a string.