### PR TITLE
Prefix path with slash when missing

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -144,6 +144,10 @@ function doRequest(o, callback){
 		}
 	}
 
+	if(path.substring(0,1) != '/') {
+		path = '/' + path;
+	}
+
 	if(o.files && o.files.length > 0 && o.method == 'GET'){
 		var err = new Error("Can't send files using GET");
 		err.code = 'CANT_SEND_FILES_USING_GET';
@@ -414,4 +418,3 @@ function extractCookies (headers) {
 }
 
 exports.doRequest = doRequest;
-


### PR DESCRIPTION
This prevents situations like `http://example.netsome/path/`