### PR TITLE
add ca support and forward cookies on redirects

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -259,6 +259,10 @@ function doRequest(o, callback){
 		requestoptions.secureProtocol = o.secureProtocol;
 	}
 
+	if(isHttps && o.ca) {
+		requestoptions.ca = o.ca;
+	}
+
 	// add custom headers:
 	if(o.headers){
 		for(var headerkey in o.headers){
@@ -321,6 +325,7 @@ function doRequest(o, callback){
 				if(o.redirectCount < o.maxRedirects){
 					o.redirectCount++;
 					o.url = res.headers.location;
+					o.cookies = extractCookies(res.headers);
 					return doRequest(o, finalCallback);
 				} else {
 					var err = new Error("Too many redirects (> " + o.maxRedirects + ")");


### PR DESCRIPTION
ca-support:
When using self-signed certs (intranet for example) need to pass along ca (certificate authority) to subsequent requests.

cookie-redirects:
when using httpntlm to establish sessions, cookies must be passed along for redirects to succeed.