### PR TITLE
Optional encode POST/PUT parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ __Arguments__
     - binary: true/false (default: __false__ ), if true, res.body will be a buffer containing the binary data
     - allowRedirects: (default: __false__ ), if true, redirects will be followed
     - maxRedirects: (default: __10__ ). For example 1 redirect will allow for one normal request and 1 extra redirected request.
+    - encodePostParameters: (default: __true__ ), if true, POST/PUT parameters names will be URL encoded.
     - timeout: (default: none). Adds a timeout to the http(s) request. Should be in milliseconds.
     - proxy, if you want to pass your request through a http(s) proxy server:
         - host: eg: "192.168.0.1"

--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -116,6 +116,10 @@ function doRequest(o, callback){
 		o.maxRedirects = 10;
 	}
 
+	if(o.encodePostParameters === undefined){
+		o.encodePostParameters = true;
+	}
+
 	var chunks = [];
 	var body; // Buffer
 	var contentType;
@@ -172,8 +176,9 @@ function doRequest(o, callback){
 
 		// if the user wants to POST/PUT files, other parameters need to be encoded using 'Content-Disposition'
 		for(var key in o.parameters){
+			var headerKey = o.encodePostParameters ? encodeURIComponent(key) : key;
 			var encodedParameter = separator + crlf
-				+ 'Content-Disposition: form-data; name="'+encodeURIComponent(key)+'"' + crlf
+				+ 'Content-Disposition: form-data; name="' + headerKey + '"' + crlf
 				+ crlf
 				+ o.parameters[key] + crlf;
 			bodyArray.push(new Buffer(encodedParameter));


### PR DESCRIPTION
Some APIs don't decode the urlencoded fields names. For example, CloudSight takes params like `name[sub]` where the `[` and `]` are encoded to `%5B` and `%5D` but are not decoded to the original chars, causing API errors.

This PR adds the setting `encodePostParameters` which defaults to _true_, but when _false_ the `encodeURIComponent` is avoided.