### PR TITLE
Add ciphers, passphrase, and pfx to requestoptions

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -258,6 +258,18 @@ function doRequest(o, callback){
 	if(isHttps && o.secureProtocol) {
 		requestoptions.secureProtocol = o.secureProtocol;
 	}
+	
+	if(isHttps && o.ciphers) {
+		requestoptions.ciphers = o.ciphers;
+	}
+
+	if(isHttps && o.passphrase ) {
+		requestoptions.passphrase  = o.passphrase ;
+	}
+
+	if(isHttps && o.pfx) {
+		requestoptions.pfx = o.pfx;
+	}
 
 	if(isHttps && o.ca) {
 		requestoptions.ca = o.ca;


### PR DESCRIPTION
Found that these options were needed for older certificate ciphers.