### PR TITLE
Fixing issue #20 by closing download file on redirect

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -322,6 +322,11 @@ function doRequest(o, callback){
 
 			// check for redirects
 			if(res.headers.location && o.allowRedirects){
+				// Close any open file
+				if (o.downloadlocation) {
+					downloadstream.end();
+				}			
+			
 				if(o.redirectCount < o.maxRedirects){
 					o.redirectCount++;
 					o.url = res.headers.location;


### PR DESCRIPTION
This is the simplest change possible to fix the issue. I tried a few other things like not creating the file until data was received but that still ends up leaving a file handle orphaned.

The change was manually tested by attempting to download the Oracle JDK which redirects twice before actually returning the data stream.