### PR TITLE
Replaced deprecated buffer expression with class method

### DIFF
--- a/lib/httpreq.js
+++ b/lib/httpreq.js
@@ -158,13 +158,13 @@ function doRequest (o, callback) {
     if (o.method === 'GET') {
       path += '?' + querystring.stringify (o.parameters);
     } else {
-      body = new Buffer (querystring.stringify (o.parameters), 'utf8');
+      body = Buffer.from (querystring.stringify (o.parameters), 'utf8');
       contentType = 'application/x-www-form-urlencoded; charset=UTF-8';
     }
   }
 
   if (o.json) {
-    body = new Buffer (JSON.stringify (o.json), 'utf8');
+    body = Buffer.from (JSON.stringify (o.json), 'utf8');
     contentType = 'application/json';
   }
 
@@ -186,7 +186,7 @@ function doRequest (o, callback) {
         + 'Content-Disposition: form-data; name="' + headerKey + '"' + crlf
         + crlf
         + o.parameters[key] + crlf;
-      bodyArray.push (new Buffer (encodedParameter));
+      bodyArray.push (Buffer.from (encodedParameter));
     }
 
     // now for the files:
@@ -209,7 +209,7 @@ function doRequest (o, callback) {
           encodedFile = crlf + encodedFile;
         }
 
-        bodyArray.push (new Buffer (encodedFile));
+        bodyArray.push (Buffer.from (encodedFile));
 
         // add binary file:
         bodyArray.push (require ('fs').readFileSync (file));
@@ -219,7 +219,7 @@ function doRequest (o, callback) {
     }
 
     var footer = crlf + separator + '--' + crlf;
-    bodyArray.push (new Buffer (footer));
+    bodyArray.push (Buffer.from (footer));
 
     // set body and contentType:
     body = Buffer.concat (bodyArray);
@@ -229,7 +229,7 @@ function doRequest (o, callback) {
   // overwrites the body if the user passes a body:
   // clears the content-type
   if (o.body) {
-    body = new Buffer (o.body, 'utf8');
+    body = Buffer.from (o.body, 'utf8');
     contentType = null;
   }
 


### PR DESCRIPTION
Replaced deprecated `new Buffer` expression with class method `Buffer.from()`